### PR TITLE
Change how bof arguments are processed

### DIFF
--- a/lib/rex/post/meterpreter/extensions/bofloader/bofloader.rb
+++ b/lib/rex/post/meterpreter/extensions/bofloader/bofloader.rb
@@ -44,7 +44,6 @@ module Rex
             def add_binary(b)
               # Add binary data to the buffer
               b = b.bytes if b.is_a? String
-              b << 0x00 # Null terminated binary data
               b_length = b.length
               b = [b_length] + b
               buf = b.pack("<Ic#{b_length}")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/bofloader.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/bofloader.rb
@@ -46,12 +46,10 @@ module Rex
 
           @@execute_bof_opts = Rex::Parser::Arguments.new(
             ['-h', '--help'] => [ false, 'Help Banner' ],
-            ['-c', '--compile'] => [ true, 'Compile the input file (requires mingw).' ],
+            ['-c', '--compile'] => [ false, 'Compile the input file (requires mingw).' ],
             ['-e', '--entry'] => [ true, "The entry point (default: #{DEFAULT_ENTRY})." ],
-            ['-f', '--format-string'] => [ true, 'bof_pack compatible format-string. Choose combination of: b, i, s, z, Z' ]
+            ['-f', '--format-string'] => [ true, 'Argument format-string. Choose combination of: b, i, s, z, Z' ]
           )
-
-          # TODO: Properly parse arguments (positional and named switches)
 
           #
           # List of supported commands.
@@ -63,14 +61,27 @@ module Rex
           end
 
           def cmd_execute_bof_help
-            print_line('Usage:   execute_bof </path/to/bof_file.o> [arguments [arguments]] --format-string [format-string]')
-            print_line('Example: execute_bof /bofs/dir.x64.o C:\\\\ 0 --format-string Zs')
-            print_line('Example: execute_bof /bofs/dir.x64.c C:\\\\ 0 --format-string Zs --compile')
+            print_line('Usage:   execute_bof </path/to/bof_file.o> [arguments] [-- bof arguments]')
             print_line(@@execute_bof_opts.usage)
+            print_line(
+              <<~HELP
+              Example:
+                execute_bof /root/dir.x64.o --format-string Zs -- C:\\ 0
+                execute_bof /bofs/dir.x64.c --compile --format-string Zs -- C:\\ 0 
+
+              Argument formats:
+                b       binary data (e.g. 01020304)
+                i       32-bit integer
+                s       16-bit integer
+                z       null-terminated utf-8 string
+                Z       null-terminated utf-16 string
+              HELP
+            )
           end
 
           # Tab complete the first argument as a file on the local filesystem
           def cmd_execute_bof_tabs(str, words)
+            return if words.include?('--')
             return tab_complete_filenames(str, words) if words.length == 1
 
             fmt = {
@@ -90,12 +101,13 @@ module Rex
               return false
             end
 
-            bof_args = nil
+            bof_args = []
             bof_args_format = nil
-            bof_cmdline = []
             entry = DEFAULT_ENTRY
             compile = false
 
+            bof_filename = args.shift
+            args, bof_args = args.split('--') if args.include?('--')
             @@execute_bof_opts.parse(args) do |opt, _idx, val|
               case opt
               when '-c', '--compile'
@@ -104,12 +116,8 @@ module Rex
                 bof_args_format = val
               when '-e', '--entry'
                 entry = val
-              when nil
-                bof_cmdline << val
               end
             end
-
-            bof_filename = bof_cmdline[0]
 
             unless ::File.file?(bof_filename) && ::File.readable?(bof_filename)
               print_error("Unreadable file: #{bof_filename}")
@@ -117,16 +125,42 @@ module Rex
             end
 
             if bof_args_format
-              if bof_args_format.length != bof_cmdline.length - 1
-                print_error("Format string length must be the same as argument length: fstring:#{bof_args_format.length}, args:#{bof_cmdline.length - 1}")
+              if bof_args_format.length != bof_args.length
+                print_error('Format string must be the same length as arguments.')
                 return
               end
-              bof_args = bof_cmdline[1..]
-            elsif bof_cmdline.length > 1
-              print_error('Arguments detected and no format string specified.')
+
+              bof_args_format.chars.each_with_index do |fmt, idx|
+                bof_arg = bof_args[idx]
+                case fmt
+                when 'b'
+                  unless bof_arg.length.even?
+                    print_error("Argument ##{idx + 1} was not appropriately padded to an even length string!")
+                    return false
+                  end
+                  bytes = bof_arg.scan(/(?:[a-fA-F0-9]{2})/).map {|v| v.to_i(16)}
+                  if (bof_arg.length / 2 != bytes.length)
+                    print_error("Argument ##{idx + 1} contains invalid characters!")
+                    return false
+                  end
+                  bof_arg = bytes.pack("C*")
+                when 'i', 's'
+                  if bof_arg =~ /^\d+$/
+                    bof_arg = bof_arg.to_i
+                  elsif bof_arg =~ /^0x[a-fA-F0-9]+$/
+                    bof_arg = bof_arg[2..].to_i(16)
+                  else
+                    print_error("Argument ##{idx + 1} must be a number!")
+                    return false
+                  end
+                end
+                bof_args[idx] = bof_arg
+              end
+            elsif bof_args.length > 1
+              print_error('Arguments detected but no format string specified.')
               return
             else
-              print_status('No argument format specified, executing bof with no arguments.')
+              print_status('No arguments specified, executing bof with no arguments.')
             end
 
             if compile


### PR DESCRIPTION
Changes how arguments are processed. Also handles numbers and binary data correctly. Binary data has to be represented in hex and not null terminated, numbers can now be specified in decimal, or hex (e.g. 0x123) formats. The binary format of aabbccdd is the same as how the existing `reg` command expects arguments for REG_BINARY.